### PR TITLE
Fix several C errors

### DIFF
--- a/inst/include/hlrmisc.h
+++ b/inst/include/hlrmisc.h
@@ -116,6 +116,8 @@ extern char *hlr_strdups (char *s1);
 */
 #define hlr_strdup0(s) ((s) ? hlr_strdup(s) : NULL)
 
+/// The maximum amount of memory meeded to to store an int
+#define HLR_ITOA_SIZE 21
 /**
    Convert an integer into a string.<br>
    Usage:<br>
@@ -126,9 +128,7 @@ extern char *hlr_strdups (char *s1);
    the result can be up to 20 bytes<br>
    (see ULONG_MAX in limits.h)<br>
 */
-#define hlr_itoa(s,i) sprintf(s,"%d",i)
-/// The maximum amount of memory meeded to to store an int
-#define HLR_ITOA_SIZE 21
+#define hlr_itoa(s,i) snprintf(s,HLR_ITOA_SIZE,"%d",i)
 
 /// Define MIN only if not defined by C library
 #ifndef MIN

--- a/src/forest.c
+++ b/src/forest.c
@@ -174,10 +174,10 @@ static void forest_descend (ForestNode k,int level) {
   dots[level] = '\0';
   if (gPrintHTML) {
     Rprintf (">");
-    Rprintf (dots);
+    Rprintf ("%s", dots);
     if (level > 0)
       Rprintf (" ");
-    Rprintf (k->name);
+    Rprintf ("%s", k->name);
     Rprintf ("\n");
   }
   else {

--- a/src/format.c
+++ b/src/format.c
@@ -516,7 +516,7 @@ int stringPrintf (Stringa str,const char *format,...) {
   va_end (args);
   array (str,maxlength + 1,char) = '\0'; // allocate space
   va_start (args,format);
-  resultLen = vsprintf (string (str),format,args);
+  resultLen = vsnprintf (string (str),maxlength + 1,format,args);
   va_end (args);
   if (resultLen > maxlength || resultLen < 0)
     die ("stringPrintf(): result length prediction failed. Memory corrupted. Abort for safety. Possible cause: %%f specified and printed representation of numeric value requires more then deflength = 18 bytes. Possible fix: use %%g as format string.");
@@ -539,7 +539,7 @@ int stringAppendf (Stringa str,const char *format,...) {
   va_end (args);
   array (str,len + maxlength + 1,char) = '\0'; // allocate space
   va_start (args,format);
-  resultLen = vsprintf (string (str)+len,format,args);
+  resultLen = vsnprintf (string (str)+len,maxlength + 1,format,args);
   va_end (args);
   if (resultLen > maxlength || resultLen < 0)
     die ("stringAppendf(): oops");
@@ -572,7 +572,7 @@ char *stringPrintBuf (const char *format,...) {
   va_end (args);
   array (str,maxlength + 1,char) = '\0'; // allocate space
   va_start (args,format);
-  resultLen = vsprintf (string (str),format,args);
+  resultLen = vsnprintf (string (str),maxlength + 1,format,args);
   va_end (args);
   if (resultLen > maxlength || resultLen < 0)
     die ("stringPrintBuf(): oops");

--- a/src/html.c
+++ b/src/html.c
@@ -211,7 +211,7 @@ void cgiHeader (char *mimeType) {
        a reload */
     struct tm *gmt = gmtime (&t);
     strftime (date,39,"%a, %d %b %Y %T GMT",gmt);
-    sprintf (exp,"\r\nExpires: %.40s",date);
+    snprintf (exp,sizeof exp,"\r\nExpires: %.40s",date);
   }
   else
     exp[0] = '\0';
@@ -632,7 +632,7 @@ void cgiEncodeWord (char *s,Stringa a) {
   stringClear (a);
   while ((c = *++cp) != '\0') {
     if (!isalnum(c) && c != '_' && c != '-' && c != '.' && c != ':') {
-      sprintf (hex,"%02X",c);
+      snprintf (hex,sizeof hex,"%02X",c);
       stringCatChar (a,'%');
       stringCatChar (a,hex[0]);
       stringCatChar (a,hex[1]);
@@ -818,7 +818,7 @@ void cgiURLCreate (char *host,int port,char *program) {
   stringCat (cgiurl,host);
   if (port != 0) {
     stringCat (cgiurl,":");
-    sprintf (portStr,"%d",port);
+    snprintf (portStr,sizeof portStr,"%d",port);
     stringCat (cgiurl,portStr);
   }
   if (program[0] != '/')

--- a/src/log.c
+++ b/src/log.c
@@ -235,7 +235,7 @@ void print_msg(const char *x, const char* prefix, va_list args) {
   fflush(NULL);
   char msg[4096];
   REprintf(prefix);
-  vsprintf(msg, x, args);
+  vsnprintf(msg, sizeof msg, x, args);
   REprintf(msg);
   va_end(args);
   REprintf("\n");
@@ -509,7 +509,7 @@ void warnAdd (char *source,char *msg) {
     free (gSources[WARNMAX-1]);
     free (gMsgs[WARNMAX-1]);
     gSources[WARNMAX-1] = strdup ("warnAdd");
-    sprintf (s,"Warning buffer overflow. Last %d warning(s) discarded.",
+    snprintf (s, sizeof s, "Warning buffer overflow. Last %d warning(s) discarded.",
              gWarnCnt - WARNMAX);
     gMsgs[WARNMAX-1] = strdup(s);
   }

--- a/src/sequenceAlignment.c
+++ b/src/sequenceAlignment.c
@@ -193,9 +193,9 @@ static void printName (char *name) {
   char line[NAME_LENGTH+1];
 
   if (name == NULL)
-    sprintf (line,"%*s",NAME_LENGTH,"");
+    snprintf (line,sizeof line,"%*s",NAME_LENGTH,"");
   else
-    sprintf (line,"%-*.*s",NAME_LENGTH,NAME_LENGTH-1,name);
+    snprintf (line,sizeof line,"%-*.*s",NAME_LENGTH,NAME_LENGTH-1,name);
   Rprintf ("%s",line);
 }
 


### PR DESCRIPTION
* `Rprintf` cannot have a non-literal as its first argument; this used to work simply because compiler diagnostics were not good enough, but some R configurations compile with `-Werror=format-security`, and this code then causes an error.
* `[v]sprintf` is blocked by `FORTIFY_SOURCE`. Fixing it should be as easy as replacing the relevant calls by `[v]snprintf`.

/cc @banfai 